### PR TITLE
(ft-getoneredflag) implement route to get a specific redflag

### DIFF
--- a/redflags__test.json
+++ b/redflags__test.json
@@ -29,7 +29,7 @@
     },
     {
       "id": 4,
-      "createdOn": "2018-11-29T19:04:16.361Z",
+      "createdOn": "2018-11-30T00:55:41.679Z",
       "createdBy": 1,
       "type": "red-flag",
       "location": "9.388939, 0.848494",

--- a/server/controllers/redflagsController.js
+++ b/server/controllers/redflagsController.js
@@ -24,7 +24,6 @@ class RedflagsController {
       });
     }
 
-
     // req.newRedflag.Image = `http://localhost:${process.env.PORT}/${req.newRedflag.Image}`;
     // return res.status(201).json({
     //   status: 201,
@@ -122,6 +121,13 @@ class RedflagsController {
     });
   }// END editRedflagComment
 
+  static async getOneRedflag(req, res) {
+    const { requestedRedflag } = req;
+    res.status(200).json({
+      status: 200,
+      data: [ requestedRedflag ]
+    });
+  }// END getOneRedflag
 
 }// END class RedflagsController
 

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -203,9 +203,26 @@ class Validate {
     req.newComment = comment.trim();
     req.redflagOwner = user[0];
     
-
     return next();
   } // END editRedflagComment
+
+
+  static async getOneRedflag(req, res, next) {
+
+    const response = message => res.status(400).json({ status: 400, error: message });
+    
+    if (!Number.isInteger(Number(req.params.id))) return response(`'${req.params.id}' is not a valid redflag id. Red-flags have only positive integer id's`);
+    if(Number(req.params.id) < 0) return response(`Red-flags have only positive integer id's`);
+
+    const { redflags } = await JSON.parse(fs.readFileSync(redflagsDotJason));
+    const requestedRedflag = redflags.filter(redflag => Number(redflag.id) === Number(req.params.id));
+    // recall: filter returns an array. thererfore, the required redflag = requestedRedflag[0], which is null if the array is empty
+
+    const emptyObj = {};
+    req.requestedRedflag = requestedRedflag[0] ? requestedRedflag[0] : emptyObj;
+    
+    return next();
+  }// END getOneRedflag
   
 
 

--- a/server/routes/redflagsRouter.js
+++ b/server/routes/redflagsRouter.js
@@ -34,6 +34,7 @@ const fileUpload = upload.fields([{name: 'images', maxCount: 8}, {name: 'videos'
 router.post('/', fileUpload, Validator.newRedflag, RedflagsController.newRedflag);
 router.patch('/:id/location', upload.none(), Validator.editRedflagLocation, RedflagsController.editRedflagLocation);
 router.patch('/:id/comment', upload.none(), Validator.editRedflagComment, RedflagsController.editRedflagComment);
+router.get('/:id', upload.none(), Validator.getOneRedflag, RedflagsController.getOneRedflag);
 
 
 

--- a/tests/routes/redflags.spec.js
+++ b/tests/routes/redflags.spec.js
@@ -530,3 +530,74 @@ describe('PATCH /redflags/:id/comment', () => {
       });
   });
 });
+/**-------------------- END PATCH /redflags/:id/comment -------------------------- */
+
+
+
+
+
+/**--------------------- GET /redflags/:id -------------- */
+describe('GET /redflags/:id', () => {
+
+    it(`should return a 400 error if an invalid red-flag id is provided as parameter`, (done) => {
+      chai.request(app)
+      .get('/api/v1/redflags/a') // 'a' is an invalid red-flag id
+      .end((err, res) => {
+        if(err) {
+          done(err);
+        }
+        res.status.should.eql(400);
+        res.body.status.should.eql(400);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'error']);
+        done();
+      });
+    });
+
+    it(`should return a 400 error if negative id is provided`, (done) => {
+      chai.request(app)
+      .get('/api/v1/redflags/-1')
+      .end((err, res) => {
+        if(err) {
+          done(err);
+        }
+        res.status.should.eql(400);
+        res.body.status.should.eql(400);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'error']);
+        done();
+      });
+    });
+
+    it(`should return an empty object if the requested red-flag does not exist`, (done) => {
+      chai.request(app)
+      .get('/api/v1/redflags/10000') // no red-flag with id 10000
+      .end((err, res) => {
+        if(err) {
+          done(err);
+        }
+        res.status.should.eql(200);
+        res.body.status.should.eql(200);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'data']);
+        res.body.data.should.be.an('array');
+        res.body.data[0].should.be.an('object'); // how can I test for an empty obj in mocha ?
+        done();
+      });
+    });
+
+    it(`should successfully return the requested red-flag`, (done) => {
+      chai.request(app)
+      .get('/api/v1/redflags/1') // no red-flag with id 10000
+      .end((err, res) => {
+        if(err) {
+          done(err);
+        }
+        res.status.should.eql(200);
+        res.body.status.should.eql(200);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'data']);
+        res.body.data.should.be.an('array');
+        res.body.data[0].should.be.an('object');
+        done();
+      });
+    });
+
+});
+/**----------------------- END GET/redflags/:id -----------*/


### PR DESCRIPTION
## Description
This pull request deals with the implementation of the route to allow user get a particular red-flag record by specifying the id of the required red-flag in a parameter in the route.

## route
GET /api/v1/redflags/:id
Where :id is the id of the requested red-flag

## How to test
Hit the above route in postman.
Or clone the repository, run 'npm install to install all the dependencies, then run 'npm test' to run the test.