### PR TITLE
(ft-getalltheredflags) implement the GET ALL route

### DIFF
--- a/redflags__test.json
+++ b/redflags__test.json
@@ -29,7 +29,7 @@
     },
     {
       "id": 4,
-      "createdOn": "2018-11-30T04:01:45.276Z",
+      "createdOn": "2018-11-30T07:56:43.314Z",
       "createdBy": 1,
       "type": "red-flag",
       "location": "9.388939, 0.848494",

--- a/server/controllers/redflagsController.js
+++ b/server/controllers/redflagsController.js
@@ -121,6 +121,16 @@ class RedflagsController {
     });
   }// END editRedflagComment
 
+  static async getAllRedflags(req, res) {
+
+    const { redflags } = req;
+
+    return res.status(200).json({
+      status: 200,
+      data: redflags
+    });
+  }// END getAllRedflags
+
   static async getOneRedflag(req, res) {
     const { requestedRedflag } = req;
     res.status(200).json({
@@ -128,6 +138,8 @@ class RedflagsController {
       data: [ requestedRedflag ]
     });
   }// END getOneRedflag
+
+
 
   static async deleteRedflag(req, res) {
     const { allRedflags, redflagToDelete, redflagOwner } = req;

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -207,6 +207,15 @@ class Validate {
   } // END editRedflagComment
 
 
+  static async getAllRedflags(req, res, next) {
+
+    const { redflags } = await JSON.parse(fs.readFileSync(redflagsDotJason));
+    req.redflags = redflags;
+    
+    return next();
+  }// END getAllRedflags
+
+
   static async getOneRedflag(req, res, next) {
 
     const response = message => res.status(400).json({ status: 400, error: message });

--- a/server/routes/redflagsRouter.js
+++ b/server/routes/redflagsRouter.js
@@ -33,6 +33,7 @@ const fileUpload = upload.fields([{name: 'images', maxCount: 8}, {name: 'videos'
 
 // router.post('/', upload.single('Image'), Validator.newRedflag, RedflagsController.newRedflag);
 router.post('/', fileUpload, Validator.newRedflag, RedflagsController.newRedflag);
+router.get('/', Validator.getAllRedflags, RedflagsController.getAllRedflags);
 router.patch('/:id/location', upload.none(), Validator.editRedflagLocation, RedflagsController.editRedflagLocation);
 router.patch('/:id/comment', upload.none(), Validator.editRedflagComment, RedflagsController.editRedflagComment);
 router.get('/:id', Validator.getOneRedflag, RedflagsController.getOneRedflag);

--- a/tests/routes/redflags.spec.js
+++ b/tests/routes/redflags.spec.js
@@ -750,3 +750,27 @@ describe('DELETE /redflags/:id', () => {
 
 });
 /**---------------------(END) DELETE /redflags/:id -------------- */
+
+
+
+
+/**--------------------- GET /redflag -------------- */
+describe('GET /redflags', () => {
+  it('should let a user successfuly get all red-flag records', (done) => {
+    chai.request(app)
+      .get('/api/v1/redflags')
+      .end((err, res) => {
+        if (err) {
+          //   console.log(err);
+          done(err);
+        }
+        res.status.should.eql(200);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'data']);
+        res.body.data.should.be.an('array');
+        // res.body.data[0].should.be.an('object').which.has.all.keys(['id', 'location', 'createdBy', 'createdOn', 'Comment', 'type', 'Image', 'Video', 'status']);
+        done();
+      });
+  });
+});
+
+/**--------------------- (END) GET /redflag -------------- */


### PR DESCRIPTION

## Description
This pull request deals with the implementation of the route to get all red-flag records.

## route
GET  /api/v1/redflags
Where id represents the id of the red-flag to be deleted.

## How to test 
Using postman: hit the above route. An array of all the red-flag records should be returned. Ensure you have created some records with the provided email.
Using the command line: clone the repository; run 'npm install' to install the necessary dependencies.
Then in the terminal, run 'npm test'.